### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -5,32 +5,32 @@
 #######################################
 
 Adafruit_NeoPixel	KEYWORD1
-Animation 		KEYWORD1
-PixelStrip	 	KEYWORD1
+Animation KEYWORD1
+PixelStrip	KEYWORD1
 
 #######################################
 # Methods and Functions 
 #######################################	
 
 setPixelColor	KEYWORD2
-setPin			KEYWORD2
+setPin	KEYWORD2
 setBrightness	KEYWORD2
-numPixels		KEYWORD2
+numPixels	KEYWORD2
 getPixelColor	KEYWORD2
-Color			KEYWORD2
+Color	KEYWORD2
 setAnimation	KEYWORD2
-reset			KEYWORD2
-draw			KEYWORD2
-animate			KEYWORD2
+reset	KEYWORD2
+draw	KEYWORD2
+animate	KEYWORD2
 getPixelCount	KEYWORD2
 
 #######################################
 # Constants
 #######################################
  
-NEO_GRB			LITERAL1
-NEO_COLMASK		LITERAL1
-NEO_KHZ800		LITERAL1
-NEO_SPDMASK		LITERAL1
-NEO_RGB			LITERAL1
-NEO_KHZ400		LITERAL1
+NEO_GRB	LITERAL1
+NEO_COLMASK	LITERAL1
+NEO_KHZ800	LITERAL1
+NEO_SPDMASK	LITERAL1
+NEO_RGB	LITERAL1
+NEO_KHZ400	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords